### PR TITLE
Export __version__ in the __init__.py

### DIFF
--- a/timeout_iterator/__init__.py
+++ b/timeout_iterator/__init__.py
@@ -1,5 +1,7 @@
 from timeout_iterator.without_terminate import without_terminate
 from timeout_iterator.terminate import terminate
 
+# https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
+from ._version import __version__
 
-__all__ = ["terminate", "without_terminate"]
+__all__ = ["terminate", "without_terminate", "__version__"]


### PR DESCRIPTION
- I've created _version.py file but it's not working as expected.
- This PR will export `__version__` in the `__init__.py` file.
