### PR TITLE
Tighten Ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,37 @@ ignore_missing_imports = false
 
 [tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "COM",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"timeout_iterator/_version.py" = [
+    "RUF022",
+]
+"tests/**/*.py" = [
+    "ANN",
+    "D",
+    "S101",
+]

--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -7,7 +7,7 @@ from timeout_iterator import terminate
 
 
 def test_terminate() -> None:
-    # If the time is shorter than the timeout, it will time out with a TimeoutError.
+    # A short timeout raises TimeoutError before the loop finishes.
     results = []
     with pytest.raises(TimeoutError):
         for i in terminate(range(10), seconds=0.3):

--- a/timeout_iterator/__init__.py
+++ b/timeout_iterator/__init__.py
@@ -1,7 +1,7 @@
-from timeout_iterator.without_terminate import without_terminate
 from timeout_iterator.terminate import terminate
+from timeout_iterator.without_terminate import without_terminate
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
 
-__all__ = ["terminate", "without_terminate", "__version__"]
+__all__ = ["__version__", "terminate", "without_terminate"]

--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -1,7 +1,7 @@
-from typing import TypeVar, Iterable
 import datetime
 import signal
-
+from collections.abc import Iterable
+from typing import TypeVar
 
 T = TypeVar("T")
 
@@ -11,12 +11,12 @@ T = TypeVar("T")
 def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
     """Timeout iterator
 
-    This iterator forcibly terminates a running task after the specified number of seconds.
+    This iterator forcibly terminates a task after the timeout expires.
     """
     now = datetime.datetime.now()
     end = now + datetime.timedelta(seconds=seconds)
 
-    def handler(signum: int, frame: object) -> None:
+    def handler(signum: int, _frame: object) -> None:
         if signum != signal.SIGALRM:
             return
         if datetime.datetime.now() < end:
@@ -27,7 +27,6 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
     signal.setitimer(signal.ITIMER_REAL, seconds)
 
     try:
-        for item in iterable:
-            yield item
+        yield from iterable
     finally:
         signal.setitimer(signal.ITIMER_REAL, 0)

--- a/timeout_iterator/without_terminate.py
+++ b/timeout_iterator/without_terminate.py
@@ -1,6 +1,6 @@
-from typing import TypeVar, Iterable
 import datetime
-
+from collections.abc import Iterable
+from typing import TypeVar
 
 T = TypeVar("T")
 


### PR DESCRIPTION
## Summary

Tighten the Ruff lint configuration with a stricter, low-friction rule set.

## Changes

- enable a broader set of non-framework-specific Ruff rules
- keep test files practical with targeted per-file ignores where needed
- update code that was auto-fixable or low-cost to adjust manually

## Verification

- `uv run poe check`
- `uv run poe test`
