### PR TITLE
Tighten Ruff McCabe complexity limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,4 +105,4 @@ select = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 4
+max-complexity = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,6 @@ select = [
     "D",
     "S101",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 4

--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -17,9 +17,7 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
     end = now + datetime.timedelta(seconds=seconds)
 
     def handler(signum: int, _frame: object) -> None:
-        if signum != signal.SIGALRM:
-            return
-        if datetime.datetime.now() < end:
+        if signum != signal.SIGALRM or datetime.datetime.now() < end:
             return
         raise TimeoutError
 


### PR DESCRIPTION
## Summary
- add Ruff McCabe `max-complexity = 4`
- lower the limit to `3`
- collapse timeout signal handling into a single guard

## Testing
- `uv run poe check`
- `uv run poe test`

## Notes
- `uv run poe build` currently fails because `build` is not installed in the project environment