### PR TITLE
Restore SIGALRM handler after terminate

### DIFF
--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -47,3 +47,17 @@ def test_terminate_4() -> None:
         signal.alarm(signal.SIGALRM)
 
     assert results == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+def test_terminate_restores_sigalrm_handler() -> None:
+    def handler(signum: int, _frame: object) -> None:
+        raise AssertionError(f"unexpected signal: {signum}")
+
+    original_handler = signal.getsignal(signal.SIGALRM)
+    signal.signal(signal.SIGALRM, handler)
+    try:
+        list(terminate(range(1), seconds=3.0))
+
+        assert signal.getsignal(signal.SIGALRM) is handler
+    finally:
+        signal.signal(signal.SIGALRM, original_handler)

--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -21,10 +21,11 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
             return
         raise TimeoutError
 
-    signal.signal(signal.SIGALRM, handler)
+    original_handler = signal.signal(signal.SIGALRM, handler)
     signal.setitimer(signal.ITIMER_REAL, seconds)
 
     try:
         yield from iterable
     finally:
         signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, original_handler)


### PR DESCRIPTION
## Summary
- Restore the previous SIGALRM handler after `terminate()` finishes or times out.
- Add regression coverage for preserving a caller-installed SIGALRM handler.

## Verification
- uv run poe check
- uv run poe test
- git diff --check
