### PR TITLE
Use reusable actionlint and gh-counter workflows

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,21 +9,7 @@ on:
       - main
 jobs:
   actionlint:
-    name: Actionlint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: stable
-
-      - name: Run actionlint
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml
-
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
- Replace local actionlint and/or gh-counter job definitions with reusable workflow callers from `kitsuyui/gh-actions-workflows`.
- Keep repository-specific workflow triggers and permissions unchanged.

## Changed files
- `.github/workflows/python-test.yml`

## Validation
- `actionlint -color=false <updated workflow files>`
- `git diff --check`
