### PR TITLE
Pin gitignore reusable workflow ref

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc # main


### PR DESCRIPTION
## Summary

- Pin the scheduled gitignore update reusable workflow to a full commit SHA.
- Keep the original branch name as an inline comment for future update context.

## Validation

- `git diff --check`
- YAML parse for `.github/workflows/gitignore-in.yml`
- `actionlint .github/workflows/gitignore-in.yml`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`