### PR TITLE
Pin PyPI publish workflow actions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,20 +10,23 @@ on:
 env:
   python_version: 3.13
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.python_version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |
@@ -34,7 +37,7 @@ jobs:
         run: uv build
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
@@ -43,7 +46,7 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Add explicit read-only `contents` permission to the PyPI publish workflow.
- Pin the checkout, Python setup, uv setup, and PyPI publish actions to full commit SHAs.
- Keep the source version as a tracking comment so dependency update tools can still open reviewable updates.

## Why

The publish workflow runs before TestPyPI/PyPI token use. Running those setup and publish actions through mutable refs lets the executed code change outside this repository's review path.

Pinning the refs closes that drift while keeping the workflow behavior unchanged.

## Validation

- `ruby -ryaml -e "YAML.load_file('.github/workflows/pypi-publish.yml')"`
- `actionlint .github/workflows/pypi-publish.yml`
- `git diff --check`