### PR TITLE
Add concurrency control to GitHub Actions workflows

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -1,6 +1,11 @@
 name: happy-commit
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   python_version: 3.13
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,11 @@
 name: Spellcheck
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

Add top-level `concurrency` settings to the GitHub Actions workflows that run on `pull_request` and/or `push`:

- `.github/workflows/happy.yml`
- `.github/workflows/octocov.yml`
- `.github/workflows/pypi-publish.yml`
- `.github/workflows/python-test.yml`
- `.github/workflows/spellcheck.yml`

The packaging workflow only cancels in-progress runs for `pull_request` events, leaving release-triggered publishing runs unaffected.

## Impact

- Cancels outdated in-progress runs for the same workflow on the same PR or branch
- Reduces unnecessary GitHub Actions usage
- Makes CI results easier to read by keeping the latest run authoritative

## Verification

- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `typos .github/workflows/*.yml`
