### PR TITLE
Cache uv dependencies in GitHub Actions

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -34,6 +34,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## Summary
- Enable the setup-uv cache in workflows that run `uv sync`.
- Use `uv.lock` as the cache dependency source for test, coverage, and packaging jobs.

## Validation
- `actionlint .github/workflows/*.yml`
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `uv run ruff check timeout_iterator tests --statistics`
- `git diff --check`

## Trade-offs
- The cache key follows `uv.lock`, so dependency updates intentionally create a cold cache on the first run after a lockfile change.
