### PR TITLE
fix: use os.kill to actually deliver signals in test_terminate_3/4

### DIFF
--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import time
 
@@ -28,23 +29,27 @@ def test_terminate_2() -> None:
 
 
 def test_terminate_3() -> None:
-    # Do not timeout if the sent signal is not SIGALRM
+    # Do not timeout if the sent signal is not SIGALRM.
+    # Use os.kill to actually deliver SIGWINCH (not signal.alarm, which
+    # schedules SIGALRM after N seconds using the signal number as a duration).
     results = []
     for i in terminate(range(10), seconds=3.0):
         results.append(i)
         time.sleep(0.1)
-        signal.alarm(signal.SIGWINCH)
+        os.kill(os.getpid(), signal.SIGWINCH)
 
     assert results == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 
 def test_terminate_4() -> None:
-    # Do not timeout if the signal sent but the time is longer than the timeout
+    # Do not timeout if SIGALRM fires but the deadline has not been reached.
+    # Use os.kill to actually deliver SIGALRM, exercising the
+    # `datetime.datetime.now() < end` guard in the handler.
     results = []
     for i in terminate(range(10), seconds=3.0):
         results.append(i)
         time.sleep(0.1)
-        signal.alarm(signal.SIGALRM)
+        os.kill(os.getpid(), signal.SIGALRM)
 
     assert results == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 


### PR DESCRIPTION
## Summary

`test_terminate_3` and `test_terminate_4` were calling `signal.alarm()` with a signal *number* (SIGWINCH=28, SIGALRM=14) as the argument. `signal.alarm()` takes *seconds*, not a signal number, so both tests were silently scheduling a future SIGALRM well past the loop's lifetime. No signal was ever delivered, and the handler's two guard conditions were never reached.

Replace with `os.kill(os.getpid(), signum)` to send the intended signal immediately:

| Test | Before (broken) | After (correct) |
|------|-----------------|-----------------|
| `test_terminate_3` | `signal.alarm(28)` — schedules SIGALRM in 28 s | `os.kill(os.getpid(), signal.SIGWINCH)` — delivers SIGWINCH now |
| `test_terminate_4` | `signal.alarm(14)` — schedules SIGALRM in 14 s | `os.kill(os.getpid(), signal.SIGALRM)` — delivers SIGALRM now |

## What each test now exercises

- **`test_terminate_3`** — delivers SIGWINCH while `terminate()` is active. SIGWINCH uses its default handler (no-op), so the iteration continues uninterrupted. Verifies that a non-SIGALRM signal does not trigger the timeout.
- **`test_terminate_4`** — delivers SIGALRM while the 3-second deadline is still in the future. The handler's `datetime.datetime.now() < end` guard returns early, so no `TimeoutError` is raised. This path was previously untested.

## Verification

- `uv run pytest` — all 7 tests pass
- `uv run ruff check .` — clean
- `uv run mypy timeout_iterator tests/` — no issues