### PR TITLE
fix: fail fast when terminate timers overlap

### DIFF
--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -61,3 +61,20 @@ def test_terminate_restores_sigalrm_handler() -> None:
         assert signal.getsignal(signal.SIGALRM) is handler
     finally:
         signal.signal(signal.SIGALRM, original_handler)
+
+
+def test_nested_terminate_fails_fast_without_leaking_timer() -> None:
+    original_handler = signal.getsignal(signal.SIGALRM)
+    original_timer = signal.getitimer(signal.ITIMER_REAL)
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="ITIMER_REAL is already active",
+        ):
+            list(terminate(terminate(range(1), seconds=1.0), seconds=3.0))
+
+        assert signal.getitimer(signal.ITIMER_REAL) == (0.0, 0.0)
+        assert signal.getsignal(signal.SIGALRM) is original_handler
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, *original_timer)
+        signal.signal(signal.SIGALRM, original_handler)

--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -6,13 +6,24 @@ from typing import TypeVar
 T = TypeVar("T")
 
 
+def _ensure_itimer_real_is_available() -> None:
+    current_timer = signal.getitimer(signal.ITIMER_REAL)
+    if current_timer == (0.0, 0.0):
+        return
+
+    message = "terminate() cannot run while ITIMER_REAL is already active"
+    raise RuntimeError(message)
+
+
 # NOTE: float type accepts int
 # https://peps.python.org/pep-0484/#the-numeric-tower
 def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
     """Timeout iterator
 
     This iterator forcibly terminates a task after the timeout expires.
+    It cannot be used while another ITIMER_REAL timer is active.
     """
+    _ensure_itimer_real_is_available()
     now = datetime.datetime.now()
     end = now + datetime.timedelta(seconds=seconds)
 


### PR DESCRIPTION
## Summary
- Reject `terminate()` while `ITIMER_REAL` is already active.
- Add regression coverage for nested terminate cleanup.

## Verification
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build` (passes with existing setuptools license deprecation warnings)
- `uvx vulture timeout_iterator tests --min-confidence 80`
- `git diff --check`
