### PR TITLE
docs: clarify behavioral difference between terminate and without_terminate

### DIFF
--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -18,9 +18,10 @@ def _ensure_itimer_real_is_available() -> None:
 # NOTE: float type accepts int
 # https://peps.python.org/pep-0484/#the-numeric-tower
 def terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
-    """Timeout iterator
+    """Timeout iterator that raises TimeoutError when the timeout expires.
 
-    This iterator forcibly terminates a task after the timeout expires.
+    Unlike `without_terminate`, this function forcibly raises TimeoutError
+    after the specified number of seconds, even mid-iteration.
     It cannot be used while another ITIMER_REAL timer is active.
     """
     _ensure_itimer_real_is_available()

--- a/timeout_iterator/without_terminate.py
+++ b/timeout_iterator/without_terminate.py
@@ -8,11 +8,11 @@ T = TypeVar("T")
 # NOTE: float type accepts int
 # https://peps.python.org/pep-0484/#the-numeric-tower
 def without_terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
-    """Timeout iterator
+    """Timeout iterator that stops gracefully without raising TimeoutError.
 
-    This iterator times out after the specified number of seconds.
-    This iterator cannot forcibly terminate a running task.
-    It just ends without executing the next task.
+    Unlike `terminate`, this function does NOT raise TimeoutError when the
+    timeout expires. It simply stops yielding further items after the deadline.
+    Cannot forcibly interrupt a task that is running between yields.
     """
     now = datetime.datetime.now()
     end = now + datetime.timedelta(seconds=seconds)


### PR DESCRIPTION
## Summary

The docstrings for `terminate` and `without_terminate` previously described
the internal mechanism (SIGALRM usage) rather than the behavioral outcome
(whether TimeoutError is raised). Users choosing between the two functions
care primarily about whether the timeout raises an error, but that
distinction was not stated upfront.

- `terminate` docstring now leads with: "raises TimeoutError when the timeout expires"
- `without_terminate` docstring now leads with: "stops gracefully without raising TimeoutError"
- Each docstring cross-references the other with the key behavioral contrast

## Changes

- `timeout_iterator/terminate.py`: rewritten docstring to state TimeoutError-raising behavior first
- `timeout_iterator/without_terminate.py`: rewritten docstring to state graceful-stop behavior first

## Verification

- `poe format`: no changes needed
- `poe check` (ruff + mypy strict): all pass
- `poe test`: 7/7 tests pass
- `vulture`: 0 dead-code findings