### PR TITLE
fix: use Iterator[T] instead of Iterable[T] as return type

### DIFF
--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -1,6 +1,6 @@
 import datetime
 import signal
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -8,7 +8,7 @@ T = TypeVar("T")
 
 # NOTE: float type accepts int
 # https://peps.python.org/pep-0484/#the-numeric-tower
-def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
+def terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
     """Timeout iterator
 
     This iterator forcibly terminates a task after the timeout expires.

--- a/timeout_iterator/without_terminate.py
+++ b/timeout_iterator/without_terminate.py
@@ -1,5 +1,5 @@
 import datetime
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -7,7 +7,7 @@ T = TypeVar("T")
 
 # NOTE: float type accepts int
 # https://peps.python.org/pep-0484/#the-numeric-tower
-def without_terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
+def without_terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
     """Timeout iterator
 
     This iterator times out after the specified number of seconds.


### PR DESCRIPTION
## Summary

Both `terminate` and `without_terminate` are generator functions (they
use `yield`/`yield from`), so their actual return type is
`Generator[T, None, None]`, which is an `Iterator[T]`. The previous
`Iterable[T]` annotation understated the capability in two ways:

- Under mypy strict, `next(terminate(...))` raises a type error because
  `Iterable` does not guarantee `__next__`.
- `Iterable[T]` implies re-iterability (like a list or set), but
  generators can only be consumed once.

`Iterator[T]` is the correct public-API return type: it guarantees
`__next__` and is standard for single-use sequences.

## Changes

- `timeout_iterator/terminate.py`: `-> Iterable[T]` → `-> Iterator[T]`, add `Iterator` import
- `timeout_iterator/without_terminate.py`: same

## Verification

- `poe format`: no changes
- `poe check` (ruff + mypy strict): all pass
- `poe test`: 7/7 tests pass
- `vulture`: 0 dead-code findings