### PR TITLE
chore: add POSIX OS classifiers to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
+    "Operating System :: POSIX",
+    "Operating System :: MacOS",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

`terminate()` uses `signal.SIGALRM` and `signal.setitimer()`, which are
POSIX-only APIs unavailable on Windows. Previously, there were no OS
classifiers in `pyproject.toml`, making the package appear to support
all platforms on PyPI. Windows users could install the package without
errors, but calling `terminate()` would raise `AttributeError`.

This change adds:
- `"Operating System :: POSIX"` — declares POSIX requirement
- `"Operating System :: MacOS"` — explicitly includes macOS (which is POSIX-compatible)

## Changes

- `pyproject.toml`: two OS classifiers added to the `classifiers` list

## Verification

- `poe format`: pyproject.toml reformatted (whitespace)
- `poe check` (ruff + mypy strict): all pass
- `poe test`: 7/7 tests pass