### PR TITLE
fix: reject invalid timeout seconds

### DIFF
--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -117,3 +117,23 @@ def test_nested_terminate_fails_fast_without_leaking_timer() -> None:
     finally:
         signal.setitimer(signal.ITIMER_REAL, *original_timer)
         signal.signal(signal.SIGALRM, original_handler)
+
+
+@pytest.mark.parametrize(
+    "seconds",
+    [0, -0.1, float("inf"), float("-inf"), float("nan")],
+)
+def test_terminate_rejects_invalid_seconds_without_signal_changes(
+    seconds: float,
+) -> None:
+    original_handler = signal.getsignal(signal.SIGALRM)
+    original_timer = signal.getitimer(signal.ITIMER_REAL)
+    try:
+        with pytest.raises(ValueError, match="positive finite"):
+            list(terminate(range(1), seconds=seconds))
+
+        assert signal.getsignal(signal.SIGALRM) == original_handler
+        assert signal.getitimer(signal.ITIMER_REAL) == original_timer
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, *original_timer)
+        signal.signal(signal.SIGALRM, original_handler)

--- a/tests/test_without_terminate.py
+++ b/tests/test_without_terminate.py
@@ -1,5 +1,7 @@
 import time
 
+import pytest
+
 from timeout_iterator import without_terminate
 
 
@@ -21,3 +23,12 @@ def test_without_terminate_2() -> None:
         time.sleep(0.1)
 
     assert results == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+@pytest.mark.parametrize(
+    "seconds",
+    [0, -0.1, float("inf"), float("-inf"), float("nan")],
+)
+def test_without_terminate_rejects_invalid_seconds(seconds: float) -> None:
+    with pytest.raises(ValueError, match="positive finite"):
+        list(without_terminate(range(1), seconds=seconds))

--- a/timeout_iterator/_seconds.py
+++ b/timeout_iterator/_seconds.py
@@ -1,0 +1,9 @@
+import math
+
+
+def validate_timeout_seconds(seconds: float) -> None:
+    if seconds > 0 and math.isfinite(seconds):
+        return
+
+    message = "seconds must be a positive finite number"
+    raise ValueError(message)

--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -3,6 +3,8 @@ import signal
 from collections.abc import Iterable, Iterator
 from typing import TypeVar
 
+from timeout_iterator._seconds import validate_timeout_seconds
+
 T = TypeVar("T")
 
 
@@ -22,8 +24,10 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
 
     This iterator forcibly terminates a task after the timeout expires.
     It cannot be used while another ITIMER_REAL timer is active.
+    The timeout must be a positive finite number of seconds.
     """
     _ensure_itimer_real_is_available()
+    validate_timeout_seconds(seconds)
     now = datetime.datetime.now()
     end = now + datetime.timedelta(seconds=seconds)
     fired = False

--- a/timeout_iterator/without_terminate.py
+++ b/timeout_iterator/without_terminate.py
@@ -2,6 +2,8 @@ import datetime
 from collections.abc import Iterable, Iterator
 from typing import TypeVar
 
+from timeout_iterator._seconds import validate_timeout_seconds
+
 T = TypeVar("T")
 
 
@@ -13,7 +15,9 @@ def without_terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
     This iterator times out after the specified number of seconds.
     This iterator cannot forcibly terminate a running task.
     It just ends without executing the next task.
+    The timeout must be a positive finite number of seconds.
     """
+    validate_timeout_seconds(seconds)
     now = datetime.datetime.now()
     end = now + datetime.timedelta(seconds=seconds)
     for item in iterable:


### PR DESCRIPTION
## Summary
- Add a shared timeout seconds validator for the public iterator helpers.
- Reject zero, negative, infinite, and NaN timeouts with `ValueError` before timeout state is configured.
- Document that timeout values must be positive and finite.

## Verification
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `uvx vulture timeout_iterator tests --min-confidence 80`
- `git diff --check`
