### PR TITLE
fix: restore SIGALRM handler if setitimer raises in terminate()

### DIFF
--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -2,6 +2,7 @@ import os
 import signal
 import time
 from collections.abc import Callable
+from unittest.mock import patch
 
 import pytest
 
@@ -116,4 +117,26 @@ def test_nested_terminate_fails_fast_without_leaking_timer() -> None:
         assert signal.getsignal(signal.SIGALRM) is original_handler
     finally:
         signal.setitimer(signal.ITIMER_REAL, *original_timer)
+        signal.signal(signal.SIGALRM, original_handler)
+
+
+def test_terminate_restores_sigalrm_handler_on_setitimer_error() -> None:
+    # Even when setitimer raises, the SIGALRM handler must be restored.
+    def sentinel(signum: int, _frame: object) -> None:
+        pass
+
+    original_handler = signal.getsignal(signal.SIGALRM)
+    signal.signal(signal.SIGALRM, sentinel)
+    try:
+        with (
+            patch(
+                "signal.setitimer",
+                side_effect=[OSError("mock error"), None],
+            ),
+            pytest.raises(OSError),
+        ):
+            list(terminate(range(1), seconds=1.0))
+
+        assert signal.getsignal(signal.SIGALRM) is sentinel
+    finally:
         signal.signal(signal.SIGALRM, original_handler)

--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -22,6 +22,9 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
 
     This iterator forcibly terminates a task after the timeout expires.
     It cannot be used while another ITIMER_REAL timer is active.
+
+    Must be called from the main thread of the main interpreter.
+    Calling from a worker thread raises ValueError.
     """
     _ensure_itimer_real_is_available()
     now = datetime.datetime.now()
@@ -39,10 +42,11 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
         )
 
     original_handler = signal.signal(signal.SIGALRM, handler)
-    signal.setitimer(signal.ITIMER_REAL, seconds)
-
     try:
-        yield from iterable
+        signal.setitimer(signal.ITIMER_REAL, seconds)
+        try:
+            yield from iterable
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
     finally:
-        signal.setitimer(signal.ITIMER_REAL, 0)
         signal.signal(signal.SIGALRM, original_handler)


### PR DESCRIPTION
## Summary

`terminate()` called `signal.signal()` and `signal.setitimer()` both before the `try/finally` block.  If `setitimer()` raised (e.g. `ItimerError` for an invalid `seconds` value), the custom SIGALRM handler installed by the preceding `signal.signal()` call was left in the process without restoration.  Any subsequent SIGALRM — from another `terminate()` call or an unrelated timer — would then invoke the stale handler with a closed-over `end` value, causing silent mis-timing or spurious `TimeoutError`.

## Changes

- **`timeout_iterator/terminate.py`**: restructure the setup/teardown so `setitimer()` is inside `try/finally`, guaranteeing the original handler is restored even when `setitimer()` raises.  Add a docstring note that `terminate()` must be called from the main thread of the main interpreter (calling from a worker thread raises `ValueError` from `signal.signal()`).
- **`tests/test_terminate.py`**: add `test_terminate_restores_sigalrm_handler_on_setitimer_error` — patches `signal.setitimer` to raise on the first call and asserts the caller's SIGALRM handler is restored.

## Verification

```
uv run poe test    # 8 passed
uv run poe check   # ruff + mypy: no issues
```

## Trade-offs

This is a minimal structural fix with no API changes.  The `seconds <= 0` and non-finite `seconds` input-validation gap (which makes the bad `setitimer` path reachable) is outside the scope of this PR.
