### PR TITLE
fix: use time.monotonic() instead of datetime.now() for timeout checks

### DIFF
--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -1,5 +1,5 @@
-import datetime
 import signal
+import time
 from collections.abc import Iterable
 from typing import TypeVar
 
@@ -13,11 +13,10 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
 
     This iterator forcibly terminates a task after the timeout expires.
     """
-    now = datetime.datetime.now()
-    end = now + datetime.timedelta(seconds=seconds)
+    end = time.monotonic() + seconds
 
     def handler(signum: int, _frame: object) -> None:
-        if signum != signal.SIGALRM or datetime.datetime.now() < end:
+        if signum != signal.SIGALRM or time.monotonic() < end:
             return
         raise TimeoutError
 

--- a/timeout_iterator/without_terminate.py
+++ b/timeout_iterator/without_terminate.py
@@ -1,4 +1,4 @@
-import datetime
+import time
 from collections.abc import Iterable
 from typing import TypeVar
 
@@ -14,9 +14,8 @@ def without_terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
     This iterator cannot forcibly terminate a running task.
     It just ends without executing the next task.
     """
-    now = datetime.datetime.now()
-    end = now + datetime.timedelta(seconds=seconds)
+    end = time.monotonic() + seconds
     for item in iterable:
-        if datetime.datetime.now() > end:
+        if time.monotonic() > end:
             break
         yield item


### PR DESCRIPTION
## Summary

`without_terminate()` and the SIGALRM handler guard in `terminate()` used `datetime.datetime.now()` (wall-clock time) for timeout calculations.  Wall-clock time is not guaranteed to be monotonically increasing: NTP corrections can move it backward, VM clock drift causes it to vary, and DST transitions can jump it.  A backward jump extends the effective timeout unexpectedly; a forward jump causes premature timeout.

`time.monotonic()` is the correct choice for measuring elapsed time — it increases monotonically within the lifetime of the process.

## Changes

- **`timeout_iterator/without_terminate.py`**: replace `import datetime` with `import time`; replace `datetime.datetime.now()` / `datetime.timedelta` with `time.monotonic()` and plain float arithmetic.
- **`timeout_iterator/terminate.py`**: same substitution for the `end` deadline and the handler's double-check guard.

## Verification

```
uv run poe test    # 7 passed
uv run poe check   # ruff + mypy: no issues
```

## Trade-offs

`time.monotonic()` does not track wall-clock time across suspend/resume on some platforms, but for an in-process timeout library this is the correct trade-off: the priority is deterministic elapsed-time measurement, not calendar alignment.
