### PR TITLE
docs: add missing import time to README usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $ pip install timeout-iterator
 but it will not raise an exception.
 
 ```python
+import time
+
 from timeout_iterator import without_terminate
 results = []
 for i in without_terminate(range(10), seconds=0.3):
@@ -37,6 +39,8 @@ This function uses `signal.SIGALRM` and `signal.setitimer()`, so it is only
 supported on Unix-like platforms that provide those signal APIs.
 
 ```python
+import time
+
 from timeout_iterator import terminate
 try:
     results = []


### PR DESCRIPTION
## Summary

Both usage examples in `README.md` call `time.sleep()` but are missing the
`import time` statement. Running either snippet as shown raises
`NameError: name 'time' is not defined`.

- Add `import time` to the `without_terminate` example
- Add `import time` to the `terminate` example

## Changes

- `README.md`: add `import time` at the top of each code block that calls `time.sleep()`

## Verification

- `poe format`: no changes needed
- `poe check` (ruff + mypy): all pass
- `poe test`: 7/7 pass
- `ruff check`: 0 findings
