### PR TITLE
fix: split README.md and LICENSE into separate package-data glob entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 Homepage = "https://github.com/kitsuyui/python-timeout-iterator"
 
 [tool.setuptools]
-package-data = { "timeout_iterator" = ["py.typed"], "*" = ["README.md, LICENSE"] }
+package-data = { "timeout_iterator" = ["py.typed"], "*" = ["README.md", "LICENSE"] }
 package-dir = { "timeout_iterator" = "timeout_iterator" }
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

The `[tool.setuptools]` `package-data` entry for `"*"` was declared as
`["README.md, LICENSE"]` — a single-element list whose only element is the
string `"README.md, LICENSE"` (a comma-separated pair). setuptools interprets
each list element as a glob pattern, so this pattern matches no file.

`README.md` and `LICENSE` are already covered by the top-level `readme` and
`license` declarations, so the current wheel is built correctly by accident.
But the `package-data` entry is wrong and can mislead future maintainers.

## Changes

- `pyproject.toml`: split `"README.md, LICENSE"` into two list elements:
  `"README.md"` and `"LICENSE"`

## Verification

- `poe format`: 1 file reformatted (unrelated whitespace; no logic change)
- `poe check` (ruff + mypy): all pass
- `poe test`: 7/7 pass
- `ruff check`: 0 findings
