### PR TITLE
fix: close upstream iterator when timeout elapses

### DIFF
--- a/tests/test_without_terminate.py
+++ b/tests/test_without_terminate.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Iterator
 
 from timeout_iterator import without_terminate
 
@@ -21,3 +22,34 @@ def test_without_terminate_2() -> None:
         time.sleep(0.1)
 
     assert results == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+class CloseableIterator(Iterator[int]):
+    def __init__(self, values: list[int]) -> None:
+        self.closed = False
+        self._values = iter(values)
+
+    def __next__(self) -> int:
+        return next(self._values)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_without_terminate_closes_upstream_on_timeout() -> None:
+    upstream = CloseableIterator([0, 1])
+
+    results = []
+    for i in without_terminate(upstream, seconds=0.01):
+        results.append(i)
+        time.sleep(0.02)
+
+    assert results == [0]
+    assert upstream.closed
+
+
+def test_without_terminate_does_not_close_upstream_on_completion() -> None:
+    upstream = CloseableIterator([0])
+
+    assert list(without_terminate(upstream, seconds=3.0)) == [0]
+    assert not upstream.closed

--- a/timeout_iterator/without_terminate.py
+++ b/timeout_iterator/without_terminate.py
@@ -1,8 +1,21 @@
 import datetime
 from collections.abc import Iterable, Iterator
-from typing import TypeVar
+from typing import Protocol, TypeGuard, TypeVar
 
 T = TypeVar("T")
+
+
+class _Closeable(Protocol):
+    def close(self) -> None: ...
+
+
+def _is_closeable(value: object) -> TypeGuard[_Closeable]:
+    return callable(getattr(value, "close", None))
+
+
+def _close_if_possible(value: object) -> None:
+    if _is_closeable(value):
+        value.close()
 
 
 # NOTE: float type accepts int
@@ -16,7 +29,9 @@ def without_terminate(iterable: Iterable[T], seconds: float) -> Iterator[T]:
     """
     now = datetime.datetime.now()
     end = now + datetime.timedelta(seconds=seconds)
-    for item in iterable:
+    iterator = iter(iterable)
+    for item in iterator:
         if datetime.datetime.now() > end:
+            _close_if_possible(iterator)
             break
         yield item


### PR DESCRIPTION
## Summary
- Close a closeable upstream iterator when `without_terminate()` stops because the timeout elapsed.
- Keep the normal completion path unchanged so upstream iterators are not closed early when iteration finishes within the timeout.
- Add tests for timeout cleanup and normal completion behavior.

## Verification
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run ruff check timeout_iterator tests`
- `git diff --check`
