### PR TITLE
ci: migrate PyPI publishing to OIDC Trusted Publisher

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -44,13 +47,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Migrate PyPI and TestPyPI publishing from long-lived API tokens to OIDC Trusted Publisher (keyless authentication).

**Changes in `.github/workflows/pypi-publish.yml`:**
- Add `id-token: write` permission to the `deploy` job
- Remove `user: __token__` and `password: ${{ secrets.* }}` from both publish steps

The `pypa/gh-action-pypi-publish` action already supports OIDC; when `id-token: write` is available and no `user`/`password` is supplied, it automatically requests a short-lived token from the GitHub OIDC provider and exchanges it with PyPI.

## Why

API tokens stored in GitHub Secrets are long-lived credentials. If Secrets are ever exposed, an attacker can publish arbitrary package versions.

OIDC Trusted Publisher eliminates stored secrets:
- The token is issued per-request, scoped to a single workflow run and timestamp
- PyPI/TestPyPI enforce that only the configured repository + workflow path can publish
- No token rotation needed

## Required manual step

Before the next release, a Trusted Publisher must be registered on both package indexes:

| Index | URL |
|---|---|
| PyPI | https://pypi.org/manage/project/python-timeout-iterator/settings/publishing/ |
| TestPyPI | https://test.pypi.org/manage/project/python-timeout-iterator/settings/publishing/ |

Settings to enter on each index:
- Owner: `kitsuyui`
- Repository: `python-timeout-iterator`
- Workflow filename: `pypi-publish.yml`
- Environment name: *(leave blank)*

After the Trusted Publisher is configured, the `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets can be removed from the repository.

## Verification

- `actionlint` passes with no warnings
- `ruff check` and `mypy` pass (no Python source changes)
- All 7 tests pass
