### PR TITLE
fix: prevent re-entrant TimeoutError from SIGALRM handler

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -44,13 +47,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -49,6 +49,15 @@ def test_terminate_4() -> None:
     assert results == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 
+def test_terminate_error_has_message() -> None:
+    # TimeoutError should include the configured limit in its message.
+    with pytest.raises(TimeoutError) as exc_info:
+        for _i in terminate(range(100), seconds=0.1):
+            time.sleep(0.05)
+    assert str(exc_info.value) != ""
+    assert "0.1s" in str(exc_info.value)
+
+
 def test_terminate_restores_sigalrm_handler() -> None:
     def handler(signum: int, _frame: object) -> None:
         raise AssertionError(f"unexpected signal: {signum}")

--- a/tests/test_terminate.py
+++ b/tests/test_terminate.py
@@ -1,5 +1,6 @@
 import signal
 import time
+from collections.abc import Callable
 
 import pytest
 
@@ -56,6 +57,30 @@ def test_terminate_error_has_message() -> None:
             time.sleep(0.05)
     assert str(exc_info.value) != ""
     assert "0.1s" in str(exc_info.value)
+
+
+def test_terminate_handler_not_reentrant(  # noqa: C901
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Capture terminate()'s SIGALRM handler and call it a second time to verify
+    # the fired flag makes re-entrant delivery a no-op.
+    captured: list[Callable[[int, object], None]] = []
+    real_fn = signal.signal
+
+    def spy(signum: int, h: signal.Handlers) -> signal.Handlers:
+        r = real_fn(signum, h)
+        if signum == signal.SIGALRM and callable(h):
+            captured.append(h)
+        return r  # type: ignore[return-value]
+
+    monkeypatch.setattr(signal, "signal", spy)
+    with pytest.raises(TimeoutError):
+        for _i in terminate(range(100), seconds=0.1):
+            time.sleep(0.05)
+
+    assert len(captured) == 1
+    # Without fired flag this would raise a second TimeoutError (end is past).
+    captured[0](signal.SIGALRM, None)
 
 
 def test_terminate_restores_sigalrm_handler() -> None:

--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -15,10 +15,13 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
     """
     now = datetime.datetime.now()
     end = now + datetime.timedelta(seconds=seconds)
+    fired = False
 
     def handler(signum: int, _frame: object) -> None:
-        if signum != signal.SIGALRM or datetime.datetime.now() < end:
+        nonlocal fired
+        if fired or signum != signal.SIGALRM or datetime.datetime.now() < end:
             return
+        fired = True
         elapsed = (datetime.datetime.now() - now).total_seconds()
         raise TimeoutError(
             f"timed out after {elapsed:.3f}s (limit: {seconds}s)",

--- a/timeout_iterator/terminate.py
+++ b/timeout_iterator/terminate.py
@@ -19,7 +19,10 @@ def terminate(iterable: Iterable[T], seconds: float) -> Iterable[T]:
     def handler(signum: int, _frame: object) -> None:
         if signum != signal.SIGALRM or datetime.datetime.now() < end:
             return
-        raise TimeoutError
+        elapsed = (datetime.datetime.now() - now).total_seconds()
+        raise TimeoutError(
+            f"timed out after {elapsed:.3f}s (limit: {seconds}s)",
+        )
 
     original_handler = signal.signal(signal.SIGALRM, handler)
     signal.setitimer(signal.ITIMER_REAL, seconds)


### PR DESCRIPTION
## Summary

`terminate()`'s SIGALRM handler had no idempotency guard. Between the moment `TimeoutError` is raised and the moment `finally` restores the original handler, the custom handler remains registered. If SIGALRM fires again in that window — from nested `terminate()` calls or external code calling `signal.alarm()` — the handler would raise a second `TimeoutError`, potentially aborting the `finally` cleanup before itimer and signal state are fully restored.

Add a `fired` flag (closure `bool`, set on first invocation) checked before the timestamp guard. Subsequent invocations return immediately, making the handler idempotent.

## Changes

- `timeout_iterator/terminate.py`: add `fired = False` in `terminate()` and `nonlocal fired; fired = True` in `handler()`
- `tests/test_terminate.py`: add `test_terminate_handler_not_reentrant` — captures the installed handler via a `signal.signal` spy, then calls it a second time and verifies no `TimeoutError` is raised (without the flag, `end` is in the past so the handler would fire again)

## Test plan

- [ ] `pytest` — all 9 tests pass
- [ ] `ruff check timeout_iterator tests` — no errors
- [ ] `mypy timeout_iterator tests` — no issues