### PR TITLE
ci: enforce coverage thresholds

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,5 +1,6 @@
 # https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
 coverage:
+  acceptable: current >= 100%
   paths:
     - coverage.xml
 codeToTestRatio:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ local_scheme = "no-local-version"
 
 [tool.poe.tasks]
 test = "pytest"
-coverage-xml = "pytest --cov=timeout_iterator --doctest-modules --cov-report=xml"
+coverage-xml = "pytest --cov=timeout_iterator --doctest-modules --cov-report=xml --cov-fail-under=100"
 format = "ruff format timeout_iterator tests"
 check = [
     { cmd = "ruff check timeout_iterator tests" },


### PR DESCRIPTION
## Summary
- require the coverage task to fail below 100% line coverage
- add the same 100% coverage gate to octocov reporting

## Verification
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `actionlint`
- `uv build`
- `uv run poe format && git diff --exit-code -- timeout_iterator tests`
- `ruby -e "require 'yaml'; p YAML.load_file('.octocov.yml')['coverage']['acceptable']"`
- `git diff --check`
