### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ loop body itself can be interrupted and raise `TimeoutError`.  Keep loop body
 code safe to interrupt at any point, or use `without_terminate` if you need the
 upstream items to be fully consumed before yielding control.
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # LICENSE
 
 BSD 3-Clause License

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` to run the same checks as CI locally via pre-commit and pre-push hooks
- CI (GitHub Actions) is kept entirely unchanged — Actions remain free for public repos

## Changes

- `lefthook.yml`: configures pre-commit (`poe check`) and pre-push (`poe check` + `poe test`) hooks; clears GIT_* environment variables so nested repositories are unaffected
- `README.md`: adds a `## Development` section documenting how to install and use the hooks

## Verification

- `uv run poe check` passes locally (ruff + mypy, no issues)
- `uv run poe test` passes locally (13 tests)
- The pre-commit hook fired and passed during commit
- The pre-push hook fired and passed (check + test) during push

## Notes

- Requires `lefthook` on your PATH (`brew install lefthook` or see https://lefthook.dev/)
- No CI workflows were modified
