### PR TITLE
ci: add pip-audit job for active dependency vulnerability scanning

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -61,3 +61,18 @@ jobs:
 
       - name: Coverage
         run: uv run poe coverage-xml
+
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Audit dependencies
+        run: uv --preview audit --frozen


### PR DESCRIPTION
## Summary

Add a `pip-audit` job to the CI workflow to actively block PRs that introduce vulnerable dependencies.

## Why active vulnerability scanning is needed

Dependabot is configured and creates alerts when a known vulnerability appears in a dependency, but it only raises passive notifications — it does not block pull requests. A contributor could merge a PR that pins a vulnerable package version before Dependabot raises an alert, or the alert could sit unresolved while a new PR lands on top of it. Active CI-level scanning closes this gap by failing the build immediately if a vulnerable package is present in the locked dependency set.

## What `uv --preview audit --frozen` does

- Reads the locked dependency set from `uv.lock` without resolving or updating anything (`--frozen`).
- Queries known CVE databases (PyPI advisory database and OSV) for every package in the lockfile.
- Exits non-zero if any package has a known vulnerability, causing CI to fail and blocking the PR from merging.

The `--preview` flag is required because the `audit` subcommand is currently in the preview feature set of uv.

## Verification

The current `uv.lock` was audited locally before this PR was opened. No known vulnerabilities were found.

## Change

`.github/workflows/python-test.yml` — added a new `pip-audit` job that runs independently of the test matrix, checking out the repository, setting up uv with the lockfile cache, and running `uv --preview audit --frozen`.
